### PR TITLE
feat: Force color mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 🌃 Dark and 🌞 Light mode with auto detection (even on server side!) made easy
 
-This module is similar to the official module [@nuxt/color-mode](https://color-mode.nuxtjs.org/) but with cookie support and server side system preference (via `sec-ch-prefers-color-scheme` header), making sure that the rendered theme on the server and client is always in sync.
+This module is similar to the official module [@nuxtjs/color-mode](https://color-mode.nuxtjs.org/) but with cookie support and server side system preference (via `sec-ch-prefers-color-scheme` header), making sure that the rendered theme on the server and client is always in sync.
 
-It currently lack many features compared to the official module, for example, not being able to force a color mode for a specific page.
+It's not a 1:1 port of `@nuxtjs/color-mode` so expect a few API changes or missing features.
 
 - [✨ &nbsp;Release Notes](/CHANGELOG.md)
 - [🏀 Online playground](https://stackblitz.com/github/Eschricht/nuxt-color-mode?file=playground%2Fapp.vue)
@@ -22,6 +22,7 @@ It currently lack many features compared to the official module, for example, no
 - 🍪 &nbsp;Cookie support
 - 🤖 &nbsp;Auto detect system [color mode](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme) (even on server side!)
 - 🎨 &nbsp;Customizable
+- 🌪️ &nbsp;Temporary force color mode on individual pages or actions
 
 ## Quick Setup
 
@@ -86,6 +87,46 @@ function changeColorMode() {
 </script>
 ```
 
+## Force color mode
+
+It's possible to temporarily force the color mode on specific pages or situations. This can be done in 3 ways:
+
+### definePageMeta
+
+```vue
+<script setup lang="ts">
+definePageMeta({
+  colorMode: 'pink'
+})
+</script>
+```
+
+### Composable
+
+```vue
+<script setup lang="ts">
+const { forceColorMode } = useColorMode()
+
+function handleError() {
+  forceColorMode('error')
+}
+
+function resetError() {
+  // Reset
+  forceColorMode()
+}
+</script>
+```
+
+### $colorMode.forcedValue
+
+```vue
+<template>
+  <div>
+    <button @click="$colorMode.forcedValue = 'pink'">FORCE 🌪️</button>
+  </div>
+</template>
+```
 
 ## Contribution
 

--- a/color-mode-options.d.ts
+++ b/color-mode-options.d.ts
@@ -1,3 +1,3 @@
 declare module '#color-mode-options' {
-  export const { classPrefix, classSuffix, cookieName, cookieOptions, dataValue, fallback, preference, systemDarkName, systemLightName }: import('./src/module.ts').ModuleOptions
+  export const { classPrefix, classSuffix, cookieName, cookieOptions, dataValue, fallback, preference, systemDarkName, systemLightName }: import('./src/runtime/types.ts').ModuleOptions
 }

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,32 +1,20 @@
 <template>
   <div>
-    Nuxt module playground!
+    <p>Nuxt module playground!</p>
 
     <div>
-      <pre><code>{{ $colorMode }}</code></pre>
+      <NuxtLink to="/">
+        Home
+      </NuxtLink>
+      -
+      <NuxtLink to="/forced">
+        Forced color mode
+      </NuxtLink>
     </div>
 
-    <div>
-      <button @click="toggleColorMode">
-        toggle
-      </button>
-    </div>
-
-    <div>
-      <button @click="colorMode.preference = 'system'">
-        system
-      </button>
-    </div>
+    <NuxtPage />
   </div>
 </template>
 
 <script setup lang="ts">
-const colorMode = useColorMode()
-
-function toggleColorMode() {
-  if (colorMode.value === 'dark')
-    colorMode.preference = 'light'
-  else
-    colorMode.preference = 'dark'
-}
 </script>

--- a/playground/assets/css/main.css
+++ b/playground/assets/css/main.css
@@ -9,6 +9,11 @@
     --bg: #fff;
   }
 
+  &.pink {
+    --color: #fff;
+    --bg: #ff69b4;
+  }
+
   body {
     background-color: var(--bg);
     color: var(--color);

--- a/playground/pages/forced.vue
+++ b/playground/pages/forced.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+definePageMeta({
+  colorMode: 'pink',
+})
+</script>
+
+<template>
+  <div>
+    Page with forced color mode
+  </div>
+</template>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const colorMode = useColorMode()
+
+function toggleColorMode() {
+  if (colorMode.value === 'dark')
+    colorMode.preference = 'light'
+  else
+    colorMode.preference = 'dark'
+}
+</script>
+
+<template>
+  <div>
+    <div>
+      <pre><code>{{ $colorMode }}</code></pre>
+    </div>
+
+    <div>
+      <button @click="toggleColorMode">
+        toggle
+      </button>
+    </div>
+
+    <div>
+      <button @click="colorMode.preference = 'system'">
+        system
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { defineNuxtModule, addPlugin, createResolver, addTemplate, addImports } from '@nuxt/kit'
-import type { useCookie } from 'nuxt/app'
+import type { ModuleOptions } from './runtime/types'
 
 export default defineNuxtModule<Partial<ModuleOptions>>({
   meta: {
@@ -38,60 +38,3 @@ export default defineNuxtModule<Partial<ModuleOptions>>({
     addImports({ name: 'useColorMode', as: 'useColorMode', from: resolver.resolve('./runtime/composable') })
   },
 })
-
-export interface ModuleOptions {
-  /**
-   * The default value of $colorMode.preference
-   * @default 'system'
-   */
-  preference: string
-
-  /**
-   * The fallback value of $colorMode.preference when the system color mode is not available
-   * @default 'light'
-   */
-  fallback: string
-
-  /**
-   * The default theme name to use when system is dark mode
-   * @default 'dark'
-   */
-  systemDarkName: string
-
-  /**
-   * The default theme name to use when system is light mode
-   * @default 'light'
-   */
-  systemLightName: string
-
-  /**
-   * The class prefix that will be added to the HTML element
-   * @default ''
-   */
-  classPrefix: string
-
-  /**
-   * The class suffix that will be added to the HTML element
-   * @default '-mode'
-   */
-  classSuffix: string
-
-  /**
-   * Whether to add a data attribute to the html tag. If set, it defines the key of the data attribute.
-   * For example, setting this to `theme` will output `<html data-theme="dark">` if dark mode is enabled.
-   * @default ''
-   */
-  dataValue: string
-
-  /**
-   * The cookie name that will be used to store the color mode preference
-   * @default 'color-mode'
-   */
-  cookieName: string
-
-  /**
-   * The cookie options that will be passed to the `useCookie` function
-   * @default {}
-   */
-  cookieOptions: Pick<Parameters<typeof useCookie>[1], 'domain' | 'sameSite' | 'expires' | 'maxAge' | 'httpOnly' | 'secure' | 'path' | 'priority' | 'partitioned'>
-}

--- a/src/runtime/composable.ts
+++ b/src/runtime/composable.ts
@@ -1,15 +1,33 @@
-import { useNuxtApp } from '#imports'
+import { reactive, toRefs, useNuxtApp } from '#imports'
 
 export interface ColorModeState {
+  forcedValue: string | undefined
   preference: string
   readonly system: 'dark' | 'light' | undefined
   readonly value: string
 }
 
-export function useColorMode(): ColorModeState {
-  const { $colorMode } = useNuxtApp()
+export function useColorMode() {
+  const { $colorMode } = useNuxtApp() as ReturnType<typeof useNuxtApp> & { $colorMode: ColorModeState }
 
-  return $colorMode
+  const {
+    forcedValue,
+    preference,
+    system,
+    value,
+  } = toRefs($colorMode)
+
+  const forceColorMode = (value?: string | undefined) => {
+    forcedValue.value = value || undefined
+  }
+
+  return reactive({
+    forcedValue,
+    preference,
+    system,
+    value,
+    forceColorMode,
+  }) as typeof $colorMode & { forceColorMode: (value: string) => void }
 }
 
 export default useColorMode

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,64 @@
+import type { useCookie } from '#app'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    colorMode?: string
+  }
+}
+
+export interface ModuleOptions {
+  /**
+   * The default value of $colorMode.preference
+   * @default 'system'
+   */
+  preference: string
+
+  /**
+   * The fallback value of $colorMode.preference when the system color mode is not available
+   * @default 'light'
+   */
+  fallback: string
+
+  /**
+   * The default theme name to use when system is dark mode
+   * @default 'dark'
+   */
+  systemDarkName: string
+
+  /**
+   * The default theme name to use when system is light mode
+   * @default 'light'
+   */
+  systemLightName: string
+
+  /**
+   * The class prefix that will be added to the HTML element
+   * @default ''
+   */
+  classPrefix: string
+
+  /**
+   * The class suffix that will be added to the HTML element
+   * @default '-mode'
+   */
+  classSuffix: string
+
+  /**
+   * Whether to add a data attribute to the html tag. If set, it defines the key of the data attribute.
+   * For example, setting this to `theme` will output `<html data-theme="dark">` if dark mode is enabled.
+   * @default ''
+   */
+  dataValue: string
+
+  /**
+   * The cookie name that will be used to store the color mode preference
+   * @default 'color-mode'
+   */
+  cookieName: string
+
+  /**
+   * The cookie options that will be passed to the `useCookie` function
+   * @default {}
+   */
+  cookieOptions: Pick<Parameters<typeof useCookie>[1], 'domain' | 'sameSite' | 'expires' | 'maxAge' | 'httpOnly' | 'secure' | 'path' | 'priority' | 'partitioned'>
+}


### PR DESCRIPTION
This will make users able to override the color mode on specific pages or actions.

3 possible ways to do this:

1. `definePageMeta`
2. Composable attribute `forceColorMode` 
3. `$colorMode.forcedValue`